### PR TITLE
remove-unused-drop-cap-style CSH-5249: remove drop-cap css style. Was…

### DIFF
--- a/components/styles/_body.scss
+++ b/components/styles/_body.scss
@@ -7,22 +7,6 @@
     color: #606060;
     margin: 12px auto;
 
-    /* class style for the DropCap property of the body component */
-    &._drop-cap {
-        &:not(.doc-empty) {
-            &:not(.doc-component-highlight) {
-                min-height: 80px;
-                &::first-letter {
-                    font-size: 300%;
-                    text-transform: uppercase;
-                    line-height: 0.8;
-                    float: left;
-                    margin: 4px 6px 0 -2px;
-                }
-            }
-        }
-    }
-
     /*
      * media query
      * $screen-sm-max constant is defined in the global style file (_common.scss)


### PR DESCRIPTION
… used in Inception, but never in Aurora. Replaced by a new solution.