### PR TITLE
dropzone-target-option CSH-5578: add data-dropzone-target option to a…

### DIFF
--- a/components/templates/html/author.html
+++ b/components/templates/html/author.html
@@ -1,4 +1,4 @@
-<div class="author">
+<div class="author" data-dropzone-target="image">
     <figure class="author-image" >
         <div doc-image="image" data-placeholder-style="hidden"></div>
     </figure>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -66,7 +66,7 @@ The full table of available directives is:
 | Directive | Behavior |
 | ------------- | ------------- |
 | doc-editable | Binds editable text to an element |
-| doc-image | Binds image text to an element |
+| [doc-image](directives/IMAGE.md) | Binds image to an element |
 | doc-container | Turns the element into a container, allowing component nesting |
 | doc-html | Replaces content of element with the raw HTML, allowing to embed content |
 | doc-slideshow | Adds slideshow functionality to element |
@@ -75,7 +75,7 @@ The full table of available directives is:
 | doc-interactive | Directive for interactive component feature |
 
 ### Styling
-Each component should also contain one [SCSS](https://sass-lang.com/guide) file as styling. Each file should contain one CSS class for one class named after the component.
+Each component should also contain one [SCSS](https://sass-lang.com/guide) file as styling. Each file should contain one CSS class for one class named after the component. This class should be added to the root html element in the template.
 
 For example, the body component styling may look like:
 ```

--- a/docs/directives/IMAGE.md
+++ b/docs/directives/IMAGE.md
@@ -21,11 +21,15 @@ The value of this attribute must match the directive key.
 
 For an example of the usage, see the `author` component in the boilerplate project.
 
-## Hiding the droppable placeholder
+## Altering the droppable placeholder style
 A placeholder overlay is shown while dragging an image and hovering the mouse over the droppable target element of the directive, informing the user an image can be dropped and what type of images are accepted.
 
-For some images this droppable placeholder is too big to display properly inside the editor. You can hide this placeholder by using the attribute `data-placeholder-style`. Currently only accepts the value `hidden`:
+For some images this droppable placeholder is too big to display properly inside the editor. You can hide this placeholder by adding the attribute `data-placeholder-style` to the element with the `doc-image` directive and setting the value to `hidden`:
 
     <div doc-image="image" data-placeholder-style="hidden"></div>
 
-For an example of the usage, see the `author` component in the boilerplate project.
+In other cases the placeholder may overlap with editable text, in which case you can alter the position by setting the value `top-left`:
+
+    <div doc-image="image" data-placeholder-style="top-left"></div>
+
+For an example of the usage, see the `author` and `hero` components in the boilerplate project.

--- a/docs/directives/IMAGE.md
+++ b/docs/directives/IMAGE.md
@@ -1,0 +1,31 @@
+# `doc-image`
+
+Binds an image to a html element. For `IMG` tag elements the image url is bound to the `src` attribute:
+
+    <img doc-image="key" src="bound-image-url">
+
+For other html elements `background-image` is set as an inline style:
+
+    <div doc-image="key" style="background-image: url('bound-image-url')></div>
+
+Inside the editor the element with the doc-image directive is turned into a droppable zone for images. This allows the user to drag and drop images from the desktop or from the attachments panel for example.
+
+## Changing the droppable zone
+In some cases you may want to change the target html element for the droppable zone inside the editor. You can do this by adding `data-dropzone-target="key"` to the target element:
+
+    <div data-dropzone-target="image">
+        <div doc-image="image"></div>
+    </div>
+
+The value of this attribute must match the directive key.
+
+For example usage see the `author` component in the boilerplate project.
+
+## Hiding droppable placeholder
+A placeholder overlay is shown when hovering the mouse of the droppable target element of the directive, informing the user an image can be dropped and what type of images are accepted.
+
+For some images this droppable placeholder is too big to display properly inside the editor. You can hide this placeholder by using the attribute `data-placeholder-style`. Currently only accepts the value `hidden`:
+
+    <div doc-image="image" data-placeholder-style="hidden"></div>
+
+For example usage see the `author` component in the boilerplate project.

--- a/docs/directives/IMAGE.md
+++ b/docs/directives/IMAGE.md
@@ -1,6 +1,6 @@
 # `doc-image`
 
-Binds an image to a html element. For `IMG` tag elements the image url is bound to the `src` attribute:
+Binds an image to an html element. For `IMG` tag elements the image url is bound to the `src` attribute:
 
     <img doc-image="key" src="bound-image-url">
 
@@ -19,13 +19,13 @@ In some cases you may want to change the target html element for the droppable z
 
 The value of this attribute must match the directive key.
 
-For example usage see the `author` component in the boilerplate project.
+For an example of the usage, see the `author` component in the boilerplate project.
 
-## Hiding droppable placeholder
-A placeholder overlay is shown when hovering the mouse of the droppable target element of the directive, informing the user an image can be dropped and what type of images are accepted.
+## Hiding the droppable placeholder
+A placeholder overlay is shown while dragging an image and hovering the mouse over the droppable target element of the directive, informing the user an image can be dropped and what type of images are accepted.
 
 For some images this droppable placeholder is too big to display properly inside the editor. You can hide this placeholder by using the attribute `data-placeholder-style`. Currently only accepts the value `hidden`:
 
     <div doc-image="image" data-placeholder-style="hidden"></div>
 
-For example usage see the `author` component in the boilerplate project.
+For an example of the usage, see the `author` component in the boilerplate project.


### PR DESCRIPTION
…uthor component template. Update documentation describing this option, as well as doc-image directive in general.