### PR TITLE
autofill-rework-CSH-5944: deprecate trigger option in 1.2.0

### DIFF
--- a/components/components-definition.json
+++ b/components/components-definition.json
@@ -1,7 +1,7 @@
 {
     "name": "default-components",
     "description": "Content Station Digital Editor components",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "defaultComponentOnEnter": "body",
 
     "components":[

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -37,8 +37,8 @@ Components use the following definition:
     "allowNesting": "yes" | "no" | "one-level",
 
     // Restricts children of this component to the listed ones.
-    // The "withContent" key can be used to filter down on the content of a directive. 
-    // For example this can be used to require that a doc-image directive has an image 
+    // The "withContent" key can be used to filter down on the content of a directive.
+    // For example this can be used to require that a doc-image directive has an image
     // applied by the user.
     "restrictChildren": {
         "image-comp": { "withContent": "image" }
@@ -61,10 +61,10 @@ Components use the following definition:
             // There is also an ability to set different trigger options. "Once" means that it will be triggered on first
             // data setting, in case of image directive - when image is added for the first time
             // Introduced in version 1.1.0
+            // Version 1.2.0 deprecated the trigger option
             "autofill": {
                 "source": "sourceDirectiveKey",
-                "metadataField": "ContentMetaData/Description", // Enterprise metadata format, case sensitive
-                "trigger": "always"     // "once" | "always", by default it is "always"
+                "metadataField": "ContentMetaData/Description" // Enterprise metadata format, case sensitive
             },
 
             // Optional property to configure groups for container directives

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg=="
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+      "version": "10.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+      "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -28,9 +28,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@woodwing/csde-components-validator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@woodwing/csde-components-validator/-/csde-components-validator-1.2.0.tgz",
-      "integrity": "sha512-IJWb+bOW9TY6rz4TSlTuqS5NCAtL1yfunTbJSpYs60mjGuCDyofQ94SYelsoQRtm/ZCVuqlu40rVBbSZhoe6Mw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@woodwing/csde-components-validator/-/csde-components-validator-1.3.0.tgz",
+      "integrity": "sha512-CJEpGmCEFTz3WjCYaiDt5GlEcUHQCVNnqBh555zsVEdGUdQUIyqR3YvscJ7fzPWS+VMCHti2RGLFoLZVY6jntA==",
       "requires": {
         "@types/htmlparser2": "^3.7.31",
         "@types/lodash": "^4.14.111",
@@ -51,14 +51,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "ajv": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+      "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.1"
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -647,9 +647,9 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
     },
     "combined-stream": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/WoodWing/csde-components-boilerplate#readme",
   "dependencies": {
-    "@woodwing/csde-components-validator": "^1.2.0",
+    "@woodwing/csde-components-validator": "^1.3.0",
     "gulp": "^4.0.0",
     "gulp-sass": "^4.0.1",
     "gulp-zip": "^4.2.0",


### PR DESCRIPTION
It will always use the "always" option. The "once" option does not function correctly in CS 11.19. 