### PR TITLE
ECS-368: Add documentation for component set limitations

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -84,3 +84,9 @@ See the following subsections for details:
 * [Scripts](SCRIPTS.md)
 
 * [Localization](LOCALIZATION.md)
+
+## Limitations
+
+The following limits are in place for component sets:
+* Maximum number of files: 5000.
+* Maximum total file size (uncompressed): 100MB.


### PR DESCRIPTION
For now, this only contains info on the component set limits. I will add the custom data documentation when the feature is fully usable (S3 download link in SNS message)