### PR TITLE
Update csde-components-validator dependency to latest version for better error messages.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,15 @@
   "requires": true,
   "dependencies": {
     "@woodwing/csde-components-validator": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@woodwing/csde-components-validator/-/csde-components-validator-1.8.0.tgz",
-      "integrity": "sha512-7gBx7gpT4xspQzpj1OBA7orr6YfiCR5bz2Fi7GFpjnKkuWIRz7JRRBY1puU/jp/CNW/QcJgiyc+RExEwpyg9cQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@woodwing/csde-components-validator/-/csde-components-validator-1.10.0.tgz",
+      "integrity": "sha512-gDofsPqSYoQsON842xtdPGMbcqeE0tvElOV6w6wOOolTDphC3bo82jk1xlJe+T6/qD05mXMuIA4H4ptGbx5fMw==",
       "requires": {
-        "ajv": "^6.5.4",
-        "ajv-errors": "^1.0.0",
-        "colors": "^1.3.2",
+        "ajv": "^7.0.4",
+        "ajv-formats": "^1.5.1",
+        "colors": "^1.4.0",
         "htmlparser2": "^3.10.0",
+        "json-source-map": "^0.6.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "pngjs": "^3.3.0",
@@ -32,20 +33,30 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
+      "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
-    "ajv-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+    "ajv-formats": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.5.1.tgz",
+      "integrity": "sha512-s1RBVF4HZd2UjGkb6t6uWoXjf6o7j7dXPQIL7vprcIT/67bTD6+5ocsU0UKShS2qWxueGDWuGfKHfOxHWrlTQg==",
+      "requires": {
+        "ajv": "^7.0.0"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -896,9 +907,9 @@
           "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
         },
         "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         }
       }
     },
@@ -2474,6 +2485,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3461,6 +3477,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/WoodWing/csde-components-boilerplate#readme",
   "dependencies": {
-    "@woodwing/csde-components-validator": "^1.8.0",
+    "@woodwing/csde-components-validator": "^1.10.0",
     "gulp": "^4.0.2",
     "gulp-zip": "^5.0.0",
     "node-sass": "^4.14.0",


### PR DESCRIPTION
The new version will show the line number & source lines for schema validation errors in components-definition.json.
This makes it easier to spot the location of the error.