### PR TITLE
CSH-9103: revert using newer sass feature.

### DIFF
--- a/component-sets/default-components/styles/_slideshow.scss
+++ b/component-sets/default-components/styles/_slideshow.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 /* Slideshow component style.
    This component is based on the jssor library. http://jssor.com/
  */
@@ -32,7 +30,7 @@ $slideshowThumbNavigatorMaxHeight: 100px;
             position: absolute;
             top: 0;
             left: 50%;
-            margin-left: -(math.div($slideshowMaxWidth, 2));
+            margin-left: -($slideshowMaxWidth / 2);
             width: $slideshowMaxWidth;
             height: $slideshowMaxHeight;
             overflow: hidden;


### PR DESCRIPTION
Currently does not work in the Digital Editor due using an older sass compiler.
As a consequence, this boilerplate project will display a deprecation warning on building.

Updating the Digital Editor sass compiler will be handled in CSH-9149.