### PR TITLE
CSH-9104: change default white-space mode to break-spaces for text fields

### DIFF
--- a/component-sets/default-components/styles/_common.scss
+++ b/component-sets/default-components/styles/_common.scss
@@ -72,6 +72,11 @@ span[data-text-edit-color] {
     padding: 0;
 }
 
+/* Render all white space in text fields. */
+[doc-editable] {
+    white-space: break-spaces;
+}
+
 /* Implements text-align property values. */
 ._align-right {
     text-align: right;


### PR DESCRIPTION
As a result:
- All whitespace is rendered, see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
- When typing multiple spaces in a row in the Digital Editor, regular spaces are inserted instead of alternating between regular and non-breaking spaces.

Note that all browsers except IE11 and Firefox for Android support `break-spaces`.