### PR TITLE
CSH-9386: Add anchor property documentation

### DIFF
--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -280,6 +280,14 @@ Example of the `slides` control type:
     }
 ```
 
+## Experimental specialized UI Controls
+
+DISCLAIMER: The UI controls in this section are marked experimental. The behavior of these controls might change in upcoming component set updates or Studio versions.
+
+### `anchor`
+
+Enables anchoring to the given component. The text anchor toolbar option will be enabled in the Digital Editor when there is at least one component in the component set that uses the `anchor` property. Users can create an anchor by selecting text in a text based component, select the anchor tool in the toolbar and then select the destination component to anchor to.
+
 ## Conditional child properties
 
 Conditional child properties provides the ability to present to the user a set of properties (child properties) depending on the value of another property (parent property)


### PR DESCRIPTION
If we like this 'experimental' section, we could opt to document `studio-object-select` in the same way.