### PR TITLE
CSH-9603: Add documentation for PSV rendering of data properties

### DIFF
--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -60,7 +60,13 @@ Data applied as inline styles to the HTML of the component.
 
 ### `data`
 
-Free style data. Does not affect the rendering of the article in the editor.
+Free style data. Data properties do not affect the HTML rendition of the article.
+
+In the PSV rendition, data properties are added as attributes to the component tag. This is supported for the controls specified in the [generic UI controls](#generic-ui-controls) section. Attributes are prefixed with `data-prop-`. For example, a property named `country` with value `Netherlands`, would result in attribute:
+
+```
+data-prop-country="Netherlands"
+```
 
 ### `doc-<directive>`
 

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -62,7 +62,7 @@ Data applied as inline styles to the HTML of the component.
 
 Free style data. Data properties do not affect the HTML rendition of the article.
 
-In the PSV rendition, data properties are added as attributes to the component tag. This is supported for the controls specified in the [generic UI controls](#generic-ui-controls) section. Attributes are prefixed with `data-prop-`. For example, a property named `country` with value `Netherlands`, would result in attribute:
+In the PSV rendition, data properties are added as attributes to the component tag. This is supported for a specific set of property control types: select, checkbox, radio, text, textarea, url, time, colorPicker and slider. Attributes are prefixed with `data-prop-`. For example, a property named `country` with value `Netherlands`, would result in attribute:
 
 ```
 data-prop-country="Netherlands"


### PR DESCRIPTION
Technically we might need to add info on the Studio version it is released in. But that might become a bit vague as it doesn't apply to bulk publish actions.

Related to: https://github.com/WoodWing/contentstation/pull/4176

Moved to DRAFT as we have to wait a bit with merging this PR. See Jira ticket for more info.