### PR TITLE
Remove whitespace placeholder image caption.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
     "singleQuote": true,
     "arrowParens": "always",
     "trailingComma": "all",
-    "tabWidth": 4
+    "tabWidth": 4,
+    "htmlWhitespaceSensitivity": "strict"
 }

--- a/component-sets/default-components/templates/html/image.html
+++ b/component-sets/default-components/templates/html/image.html
@@ -1,4 +1,7 @@
 <figure class="image">
     <div doc-image="image" doc-link="hyperlink"></div>
-    <figcaption doc-editable="caption">Image caption, sem vel consectetur dignissim, quam felis molestie lorem, eget posuere felis turpis vitae odio.</figcaption>
+    <figcaption doc-editable="caption"
+        >Image caption, sem vel consectetur dignissim, quam felis molestie lorem, eget posuere felis turpis vitae
+        odio.</figcaption
+    >
 </figure>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "yargs": "^17.3.1"
       },
       "devDependencies": {
-        "prettier": "~2.2.1"
+        "prettier": "~2.8.4"
       }
     },
     "node_modules/@woodwing/studio-component-set-tools": {
@@ -723,15 +723,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/printj": {
@@ -1688,9 +1691,9 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "printj": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "yargs": "^17.3.1"
   },
   "devDependencies": {
-    "prettier": "~2.2.1"
+    "prettier": "~2.8.4"
   }
 }


### PR DESCRIPTION
Since #110 we default to rendering the whitespace. This would make the placeholder of the image component look bigger.

Before:
![Screenshot 2023-02-16 at 14 27 45](https://user-images.githubusercontent.com/6328924/219378622-0e9e334e-8a62-422a-a06d-16705a89b780.png)

After
![Screenshot 2023-02-16 at 14 31 02](https://user-images.githubusercontent.com/6328924/219378669-dd4d51b7-f4f0-4c7d-9bcc-a0396eada83e.png)
